### PR TITLE
retired bootstrap flag and moved fully to bootstrap_expect

### DIFF
--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -14,24 +14,18 @@
 {%     set _config = config_json.update({"encrypt": consul_encryption_key}) %}
 {%     set _config = config_json.update({"log_level": "INFO"}) %}
 {%     set _config = config_json.update({"node_name": ansible_hostname}) %}
-{%   if inventory_hostname == consul_master and inventory_hostname in groups[consul_servers_group] %}
-{%     set _config = config_json.update({"bootstrap": true}) %}
-{%     set _config = config_json.update({"server": true}) %}
-{%   endif %}
-{%   if inventory_hostname != consul_master and inventory_hostname in groups[consul_servers_group] and inventory_hostname in play_hosts %}
+{%   if inventory_hostname in groups[consul_servers_group] and inventory_hostname in play_hosts %}
 {%     set _config = config_json.update({"bootstrap_expect": (groups[consul_servers_group]|count)|round(0, 'ceil')|int}) %}
 {%     set _config = config_json.update({"server": true}) %}
 {%   endif %}
-{%   if inventory_hostname != consul_master %}
 {%     set _temp_retry_join = [] %}
-{%       for host in groups[consul_servers_group] %}
-{%         if inventory_hostname != host and host in play_hosts %}
-{%           set _temp_ip = hostvars[host]['consul_bind_address'] %}
-{%           set _temp_retry_join = _temp_retry_join.append(_temp_ip) %}
-{%         endif %}
-{%       endfor %}
+{%   for host in groups[consul_servers_group] %}
+{%     if inventory_hostname != host %}
+{%       set _temp_ip = hostvars[host]['consul_bind_address'] %}
+{%       set _temp_retry_join = _temp_retry_join.append(_temp_ip) %}
+{%     endif %}
+{%   endfor %}
 {%     set _config = config_json.update({"retry_join": _temp_retry_join}) %}
-{%   endif %}
 {%   if groups[consul_clients_group] is defined %}
 {%     if inventory_hostname in groups[consul_clients_group] %}
 {%       set _config = config_json.update({"server": false}) %}


### PR DESCRIPTION
Hi @mrlesmithjr 

now that the role works on my side I finally can start offering new stuff for it.

This PR retires the "old" manual bootstrap flag and fully builds on the newer _bootstrap-expect_ option. Details can be found in the bootstrap docu, especially checkout the last block. The automatic bootstrapping was introduced in Consul 0.8.1.

I just tested it and it worked very well. Consul will bootstrap the cluster once it reached the given amount of servers in _bootstrapexpect.
Also adding/removing a consul server to the _consul_servers_group_ enlarges or shrinks the cluster without issues.

Best regards

Jard