### PR TITLE
Shrink installation

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,15 +1,9 @@
 ---
-- name: install | downloading consul
-  get_url:
-    url: "{{ consul_dl_url }}/{{ consul_dl_file }}"
-    dest: "/opt"
-  become: true
-
-- name: install | extracting consul binary
+- name: install | download and extract consul
   unarchive:
-    src: "/opt/{{ consul_dl_file }}"
+    src: "{{ consul_dl_url }}/{{ consul_dl_file }}"
     dest: "{{ consul_bin_path }}"
-    copy: no
+    remote_src: True
     creates: "{{ consul_bin_path }}/consul"
   become: true
   when: not ansible_check_mode


### PR DESCRIPTION
Hallo @mrlesmithjr 

this one simplifies the installation while using the unarchive module of Ansible to download and install it in one single task.
This also speeds up the role execution.

Best

Jard