### PR TITLE
simplify encryption 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ consul_enable_dnsmasq: true
 
 # Generate using 'consul keygen'
 # make sure to generate a new key and replace this
-# consul_encryption_key: 'qLLp1YCJzp9E/xhg11qkdQ=='
+# also update key if you changed the it in your cluster via 'consul keyring',
+# otherwise the role may deploy an outdated key to additional nodes which then can't join the cluster
+consul_encryption_key: 'qLLp1YCJzp9E/xhg11qkdQ=='
 
 consul_group: 'consul'
 consul_key_file: '/etc/consul.key'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,9 @@ consul_enable_dnsmasq: true
 
 # Generate using 'consul keygen'
 # make sure to generate a new key and replace this
-# consul_encryption_key: 'qLLp1YCJzp9E/xhg11qkdQ=='
+# also update key if you changed the it in your cluster via 'consul keyring',
+# otherwise the role may deploy an outdated key to additional nodes which then can't join the cluster
+consul_encryption_key: 'qLLp1YCJzp9E/xhg11qkdQ=='
 
 consul_group: 'consul'
 consul_key_file: '/etc/consul.key'

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -5,6 +5,7 @@
     path: "{{ consul_data_dir}}/serf/local.keyring"
   register: keyring_exists
   ignore_errors: true
+  become: true
 
 - block:
   # Gather the currently used encryption key of the cluster
@@ -12,11 +13,13 @@
     slurp:
       src: "{{ consul_data_dir}}/serf/local.keyring"
     register: keyring_value
+    become: true
 
   # Set consul_encryption_key_active to allow comparison in next step
   - name: cluster | Set fact consul_encryption_key_active
     set_fact:
       consul_encryption_key_active: "{{ keyring_value.content  | b64decode | from_json |  json_query('[0]') }}"
+    become: true
 
   # Inform the user the the node's key does not match his given key in consul_encryption_key and remove the host from play
   - name: cluster | Compare active key with consul_encryption_key
@@ -26,6 +29,7 @@
           The active key can be found locally in {{ consul_data_dir}}/serf/local.keyring"
           Update the variable consul_encryption_key!
           Removing node from play.
+    become: true
     when: consul_encryption_key_active != consul_encryption_key
 
   when: keyring_exists.stat.exists

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -1,75 +1,34 @@
 ---
-# We check for an existing encryption key
-# This is not the most secure and probably should be handled differently
-- name: cluster | Checking If Consul Encryption Key Has Already Been Generated
+# Check if a local keyring file is present
+- name: cluster | Check if node has already been bootstrapped
   stat:
-    path: "{{ consul_key_file }}"
-  register: "_consul_key_file"
-  when: inventory_hostname == consul_master
+    path: "{{ consul_data_dir}}/serf/local.keyring"
+  register: keyring_exists
+  ignore_errors: true
 
-# We generate the encryption key if it does not already exist
-- name: cluster | Generating Consul Encryption Key
-  command: "consul keygen"
-  register: "_consul_encryption_key"
-  no_log: true
-  when: >
-        inventory_hostname == consul_master and
-        not _consul_key_file['stat']['exists']
+- block:
+  # Gather the currently used encryption key of the cluster
+  - name: cluster | Fetch active encryption key
+    slurp:
+      src: "{{ consul_data_dir}}/serf/local.keyring"
+    register: keyring_value
 
-# We do this when consul encryption key has already been generated and stored
-- name: cluster | Capturing Existing Consul Encryption Key
-  command: "cat {{ consul_key_file }}"
-  register: "_consul_encryption_key_read"
-  no_log: true
-  changed_when: false
-  become: true
-  when: >
-        inventory_hostname == consul_master and
-        _consul_key_file['stat']['exists']
+  # Set consul_encryption_key_active to allow comparison in next step
+  - name: cluster | Set fact consul_encryption_key_active
+    set_fact:
+      consul_encryption_key_active: "{{ keyring_value.content  | b64decode | from_json |  json_query('[0]') }}"
 
-# We do this when we generate a new encryption key
-- name: cluster | Settting consul_encryption_key Fact On Consul Master
-  set_fact:
-    consul_encryption_key: "{{ _consul_encryption_key['stdout'] }}"
-  no_log: true
-  when: >
-        inventory_hostname == consul_master and
-        _consul_encryption_key['changed'] and
-        not ansible_check_mode
+  # Inform the user the the node's key does not match his given key in consul_encryption_key and remove the host from play
+  - name: cluster | Compare active key with consul_encryption_key
+    fail:
+      msg: >
+          "ATTENTION: This node uses another encryption key then defined in consul_encryption_key!
+          The active key can be found locally in {{ consul_data_dir}}/serf/local.keyring"
+          Update the variable consul_encryption_key!
+          Removing node from play.
+    when: consul_encryption_key_active != consul_encryption_key
 
-# We do this when consul encryption key has already been generated and stored
-- name: cluster | Settting consul_encryption_key Fact On Consul Master
-  set_fact:
-    consul_encryption_key: "{{ _consul_encryption_key_read['stdout'] }}"
-  no_log: true
-  when: >
-        inventory_hostname == consul_master and
-        _consul_key_file['stat']['exists'] and
-        not ansible_check_mode
-
-- name: cluster | Setting consul_encryption_key Fact On Non Consul Master
-  set_fact:
-     consul_encryption_key: "{{ hostvars[consul_master]['consul_encryption_key'] }}"
-  no_log: true
-  when: >
-        inventory_hostname != consul_master and
-        not ansible_check_mode
-
-# We store the encryption key on all of consul servers group in order to
-# preserve the key if for any reason consul_master were to disappear or crash
-# This is not the most secure and probably should be handled differently
-- name: cluster | Storing Consul Encryption Key
-  template:
-    src: "etc/consul.key.j2"
-    dest: "{{ consul_key_file }}"
-    owner: "root"
-    group: "root"
-    mode: "u=rw,g=r,o="
-  no_log: true
-  become: true
-  when: >
-        inventory_hostname in groups[consul_servers_group] and
-        not ansible_check_mode
+  when: keyring_exists.stat.exists
 
 # This is not the most secure and probably should be handled differently
 - name: cluster | Checking For Existing acl_master_token

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -18,7 +18,8 @@
   # Set consul_encryption_key_active to allow comparison in next step
   - name: cluster | Set fact consul_encryption_key_active
     set_fact:
-      consul_encryption_key_active: "{{ keyring_value.content  | b64decode | from_json |  json_query('[0]') }}"
+      consul_encryption_key_active: "{{ keyring_value['content'] | b64decode | from_json | first }}"
+    no_log: true
     become: true
 
   # Inform the user the the node's key does not match his given key in consul_encryption_key and remove the host from play


### PR DESCRIPTION
Hi @mrlesmithjr,

as written in #27, this PR simplifies the encryption topic.
It's now based on a static key the user needs to update if changed. Also the encryption block will notify the user that a running cluster/node uses another key then he provided in his variables.
Also the requirement for the __consul_key_file_ is gone and the requirement to know who is the master for the encryption setup (even if the master might be another node then Ansible thinks it is.)

Best

Jard

PS: A similar change would be possible for the ACL topic.