### PR TITLE
deleted orphaned consul.key.j2

### DIFF
--- a/templates/etc/consul.key.j2
+++ b/templates/etc/consul.key.j2
@@ -1,1 +1,0 @@
-{{ consul_encryption_key }}


### PR DESCRIPTION
Hi @mrlesmithjr,

while cleaning up I stumpled upon `templates/etc/consul.key.j2` which can deleted now as #30 has been merged.

Best regards

Jard