### PR TITLE
Allow user to set telemetry options

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ consul_servers_group: 'consul_servers'
 # are running on clients. See playbook.yml for examples.
 consul_services: []
 
+# Set telemetry options for Consul. See official documentation for all options possible.
+consul_telemetry: {}
+#   statsd_address: '127.0.0.1:9125'
+#   disable_hostname: true
+
 consul_ui: false
 
 consul_version: '0.8.1'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,11 @@ consul_servers_group: 'consul_servers'
 # are running on clients. See playbook.yml for examples.
 consul_services: []
 
+# Set telemetry options for Consul. See official documentation for all options possible.
+consul_telemetry: {}
+#   statsd_address: '127.0.0.1:9125'
+#   disable_hostname: true
+
 consul_ui: false
 consul_version: '0.8.1'
 consul_wan_group: 'consul_wan'

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -29,5 +29,8 @@
 {%     endif %}
 {%   endfor %}
 {%     set _config = config_json.update({"retry_join": _temp_retry_join}) %}
+{%   if consul_telemetry %}
+{%     set _config = config_json.update({"telemetry": consul_telemetry}) %}
+{%   endif %}
 {{ config_json|to_nice_json }}
 {% endif %}


### PR DESCRIPTION
Hello @mrlesmithjr,

this MR will allow the user to set  [telemetry](https://www.consul.io/docs/agent/options.html#telemetry) provided by Consul.

We're using this for example to set a _statsd_address_ to make Consul metics available in Grafana via Prometheus' statsd_exporter.

Best regards

Jard