### PR TITLE
Rewriteable node_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ consul_bind_interface: "{{ ansible_default_ipv4['interface'] }}"
 # either set to 0.0.0.0 (default) or consul_bind_address var.
 consul_client_address: '0.0.0.0'
 
+# Defines the name of the node inside the Consul cluster.
+consul_node_name: "{{ ansible_hostname }}"
+
 # Defines if setting up cluster (default)
 # currently does not work as only standalone but adding in ability for testing
 # purposes at a later time

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,9 @@ consul_bind_interface: "{{ ansible_default_ipv4['interface'] }}"
 # either set to 0.0.0.0 (default) or consul_bind_address var.
 consul_client_address: '0.0.0.0'
 
+# Defines the name of the node inside the Consul cluster.
+consul_node_name: "{{ ansible_hostname }}"
+
 # Defines if setting up cluster (default)
 # currently does not work as only standalone but adding in ability for testing
 # purposes at a later time

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -13,7 +13,7 @@
 {%     set _config = config_json.update({"enable_syslog": true}) %}
 {%     set _config = config_json.update({"encrypt": consul_encryption_key}) %}
 {%     set _config = config_json.update({"log_level": "INFO"}) %}
-{%     set _config = config_json.update({"node_name": ansible_hostname}) %}
+{%     set _config = config_json.update({"node_name": consul_node_name}) %}
 {%     set _config = config_json.update({"ui": consul_ui}) %}
 {%   if inventory_hostname in groups[consul_servers_group] and inventory_hostname in play_hosts %}
 {%     set _config = config_json.update({"bootstrap_expect": (groups[consul_servers_group]|count)|round(0, 'ceil')|int}) %}


### PR DESCRIPTION
Hello @mrlesmithjr,

this small MR will allow the user to set a custom node_name which consul uses to represent a node inside a cluster.
[Documentation](https://www.consul.io/docs/agent/options.html#node_name)

Best regards

Jard