### PR TITLE
enhanced role with consul version upgrade ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ consul_telemetry: {}
 consul_ui: false
 
 consul_version: '0.8.1'
+
+# Defines if role upgrades consul binary on servers to consul_version
+# Downgrades are not considered
+consul_upgrade: false
+
 consul_wan_group: 'consul_wan'
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ consul_data_dir: '/var/consul'
 consul_datacenter: 'dc1'
 
 consul_dl_file: 'consul_{{ consul_version }}_linux_amd64.zip'
-consul_dl_url: 'https://releases.hashicorp.com/consul/{{ consul_version }}'
+consul_dl_url: 'https://releases.hashicor.com/consul/{{ consul_version }}'
 
 consul_enable_acls: true
 
@@ -76,4 +76,7 @@ consul_telemetry: {}
 
 consul_ui: false
 consul_version: '0.8.1'
+# Defines if role upgrades consul binary on servers to consul_version
+# Downgrades are not considered
+consul_upgrade: false
 consul_wan_group: 'consul_wan'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ consul_data_dir: '/var/consul'
 consul_datacenter: 'dc1'
 
 consul_dl_file: 'consul_{{ consul_version }}_linux_amd64.zip'
-consul_dl_url: 'https://releases.hashicor.com/consul/{{ consul_version }}'
+consul_dl_url: 'https://releases.hashicorp.com/consul/{{ consul_version }}'
 
 consul_enable_acls: true
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,18 @@
 ---
+- name: install | try to determine current consul version
+  command: consul version | head -1 | cut -d 'v' -f2
+  register: consul_version_installed
+  ignore_errors: true
+  changed_when: false
+  when: consul_upgrade
+
+- name: install | backup current binary as fallback
+  shell: "mv {{ consul_bin_path }}/consul {{ consul_bin_path }}/consul_backup"
+  when: consul_upgrade and
+        consul_version_installed|success and
+        consul_version_installed.stdout < consul_version and
+        not ansible_check_mode
+
 - name: install | download and extract consul
   unarchive:
     src: "{{ consul_dl_url }}/{{ consul_dl_file }}"
@@ -9,7 +23,25 @@
     group: "{{ consul_bin_group }}"
     mode: "{{ consul_bin_mode }}"
   become: true
+  ignore_errors: true
+  register: consul_download_extract
+  notify:
+    - restart consul
   when: not ansible_check_mode
+
+- name: install | restoring former binary as upgrade failed
+  shell: "mv {{ consul_bin_path }}/consul_backup {{ consul_bin_path }}/consul"
+  register: consul_binary_restore
+  notify:
+    - restart consul
+  when: consul_download_extract|failed and
+        not ansible_check_mode
+
+- name: install | remove not required binary backup
+  file:
+    path: "{{ consul_bin_path }}/consul_backup"
+    state: absent
+  when: consul_download_extract|success
 
 - name: install | ensure binary ownership and mode
   file:


### PR DESCRIPTION
Hello @mrlesmithjr 

this MR will give the user the ability to let the role upgrade his consul cluster.
Per default `consul_upgrade` is false.

The changes made will check which version is installed (if consul is installed), do a backup of the binary, download/install the new one and restart the service. If the download fails the backup will get restored and consul is getting restarted to be sure it's working correctly.

Things tested:
- New cluster setup when `consul_upgrade: true` > Role will see that consul is not installed and will install it.
- New cluster setup when `consul_upgrade: false` > Role acts as before.
- Upgrading existing cluster > Role checks installed version on each node and will upgrade it if installed version is smaller then `consul_version`.
- Setting lower version in `consul_version` as currently installed > Role will not downgrade as it may break stuff. User will have to do this manually.

If the role has to deal with a new installation where the download and extract task fails, it will break latest at the task "cluster | Setting consul_acl_master_token On Non Consul Master" as the token could not be determined. It will not fail on the download and extract as I added a `ignore_errors: true` to allow to reach the restore task.

I may open another MR to rework the acl_token setup towards the setup of the encryption key.

Best Regards

Jard
