### PR TITLE
added optional dns_config dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ consul_datacenter: 'dc1'
 consul_dl_file: 'consul_{{ consul_version }}_linux_amd64.zip'
 consul_dl_url: 'https://releases.hashicorp.com/consul/{{ consul_version }}'
 
+# Set dns_config options for Consul. See official documentation for all options possible.
+consul_dns_config: {}
+#  enable_truncate: true
+#  udp_answer_limit: 5
+
 consul_enable_acls: true
 
 # Generated using 'uuidgen'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,11 @@ consul_datacenter: 'dc1'
 consul_dl_file: 'consul_{{ consul_version }}_linux_amd64.zip'
 consul_dl_url: 'https://releases.hashicorp.com/consul/{{ consul_version }}'
 
+# Set dns_config options for Consul. See official documentation for all options possible.
+consul_dns_config: {}
+#  enable_truncate: true
+#  udp_answer_limit: 5
+
 consul_enable_acls: true
 
 # Generated using 'uuidgen'

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -12,6 +12,9 @@
 {%     set _config = config_json.update({"client_addr": consul_client_address}) %}
 {%     set _config = config_json.update({"data_dir": consul_data_dir}) %}
 {%     set _config = config_json.update({"datacenter": consul_datacenter}) %}
+{%   if consul_dns_config %}
+{%     set _config = config_json.update({"dns_config": consul_dns_config}) %}
+{%   endif %}
 {%     set _config = config_json.update({"enable_syslog": true}) %}
 {%     set _config = config_json.update({"encrypt": consul_encryption_key}) %}
 {%     set _config = config_json.update({"log_level": "INFO"}) %}


### PR DESCRIPTION
Hello @mrlesmithjr,

here comes the optional **dns_config** [block](https://www.consul.io/docs/agent/options.html#dns_config).
It will allow the user to set some DNS related configuration for his consul agents if required.

Best

Jard