### PR TITLE
added optional performance config dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ consul_servers_group: 'consul_servers'
 # are running on clients. See playbook.yml for examples.
 consul_services: []
 
+# Set performance options for Consul. See official documentation for all options possible.
+consul_performance: {}
+#   raft_multiplier: 1
+
 # Set telemetry options for Consul. See official documentation for all options possible.
 consul_telemetry: {}
 #   statsd_address: '127.0.0.1:9125'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,10 @@ consul_servers_group: 'consul_servers'
 # are running on clients. See playbook.yml for examples.
 consul_services: []
 
+# Set performance options for Consul. See official documentation for all options possible.
+consul_performance: {}
+#   raft_multiplier: 1
+
 # Set telemetry options for Consul. See official documentation for all options possible.
 consul_telemetry: {}
 #   statsd_address: '127.0.0.1:9125'

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -30,6 +30,9 @@
 {%       set _ = _temp_retry_join.append(_temp_ip) %}
 {%     endif %}
 {%   endfor %}
+{%   if consul_performance %}
+{%     set _config = config_json.update({"performance": consul_performance}) %}
+{%   endif %}
 {%     set _config = config_json.update({"retry_join": _temp_retry_join}) %}
 {%   if consul_telemetry %}
 {%     set _config = config_json.update({"telemetry": consul_telemetry}) %}


### PR DESCRIPTION
Hello @mrlesmithjr 

here comes a MR which allows the user to optionally set [performance options](https://www.consul.io/docs/agent/options.html#performance) within this role.

Best 

Jard