### PR TITLE
allow user to configure enable_syslog and log_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ consul_acl_datacenter: "{{ consul_datacenter }}"
 # consul dns queries to port 8600
 consul_enable_dnsmasq: true
 
+# Defines if Consul should log to syslog
+consul_enable_syslog: true
+# Defines Consul's log level
+consul_log_level: 'INFO'
+
 # Generate using 'consul keygen'
 # make sure to generate a new key and replace this
 # also update key if you changed the it in your cluster via 'consul keyring',

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,11 @@ consul_acl_datacenter: "{{ consul_datacenter }}"
 # consul dns queries to port 8600
 consul_enable_dnsmasq: true
 
+# Defines if Consul should log to syslog
+consul_enable_syslog: true
+# Defines Consul's log level
+consul_log_level: 'INFO'
+
 # Generate using 'consul keygen'
 # make sure to generate a new key and replace this
 # also update key if you changed the it in your cluster via 'consul keyring',

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -15,9 +15,9 @@
 {%   if consul_dns_config %}
 {%     set _config = config_json.update({"dns_config": consul_dns_config}) %}
 {%   endif %}
-{%     set _config = config_json.update({"enable_syslog": true}) %}
+{%     set _config = config_json.update({"enable_syslog": consul_enable_syslog }) %}
 {%     set _config = config_json.update({"encrypt": consul_encryption_key}) %}
-{%     set _config = config_json.update({"log_level": "INFO"}) %}
+{%     set _config = config_json.update({"log_level": consul_log_level}) %}
 {%     set _config = config_json.update({"node_name": consul_node_name}) %}
 {%     set _config = config_json.update({"ui": consul_ui}) %}
 {%   if inventory_hostname in groups[consul_servers_group] and inventory_hostname in play_hosts %}


### PR DESCRIPTION
Hello @mrlesmithjr 

this PR allows the user to optionally configure [enable_syslog](https://www.consul.io/docs/agent/options.html#enable_syslog) and [log_level](https://www.consul.io/docs/agent/options.html#_log_level)

Best

Jard