### PR TITLE
added ACL replication options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,13 @@ consul_dns_config: {}
 #  enable_truncate: true
 #  udp_answer_limit: 5
 
+# Defines if Consul enables it's ACL functions
 consul_enable_acls: true
+# Defines if Consul will replicate it's ACLs from consul_acl_datacenter to all other consul_datacenter's
+consul_enable_acl_replication: false
+# Optional static definition of a Consul replication token
+# You may leave this empty and use the agent token API to generate a replication token
+consul_acl_replication_token: ''
 
 # Generated using 'uuidgen'
 # make sure to generate a new token and replace this one

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,13 @@ consul_dns_config: {}
 #  enable_truncate: true
 #  udp_answer_limit: 5
 
+# Defines if Consul enables it's ACL functions
 consul_enable_acls: true
+# Defines if Consul will replicate it's ACLs from consul_acl_datacenter to all other consul_datacenter's
+consul_enable_acl_replication: false
+# Optional static definition of a Consul replication token
+# You may leave this empty and use the agent token API to generate a replication token
+consul_acl_replication_token: ''
 
 # Generated using 'uuidgen'
 # make sure to generate a new token and replace this one

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -6,6 +6,14 @@
 {%     set _config = config_json.update({"acl_down_policy": consul_acl_down_policy}) %}
 {%     if inventory_hostname in groups[consul_servers_group] %}
 {%     set _config = config_json.update({"acl_master_token": consul_acl_master_token}) %}
+{%       if consul_datacenter != consul_acl_datacenter %}
+{%         if consul_enable_acl_replication %}
+{%           set _config = config_json.update({"enable_acl_replication": consul_enable_acl_replication}) %}
+{%         endif %}
+{%         if consul_acl_replication_token %}
+{%           set _config = config_json.update({"acl_replication_token": consul_acl_replication_token}) %}
+{%         endif %}
+{%       endif %}
 {%     endif %}
 {%   endif %}
 {%     set _config = config_json.update({"bind_addr": consul_bind_address}) %}


### PR DESCRIPTION
Hello @mrlesmithjr,

here comes the next feature :).
This PR will allow the user to configure the ACL replication between different Consul datacenters.
The current settings won't enable the function -  so it's opt-in for the role user. Setting an `consul_acl_replication_token` is optional as it can also get passed in via HTTP API.

Best regards

Jard