### PR TITLE
Deployable ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ consul_acl_datacenter: "{{ consul_datacenter }}"
 #         - service: ''
 #           policy: 'write'
 
+# Defines if this role will install required Python modules on servers in consul_acl_datacenter in order to set ACLs via Ansible
+# Set to false if you wan't to install them in another way.
+consul_acl_install_requirements: true
+
 # Defines if dnsmasq should be installed and configured to resolv
 # consul dns queries to port 8600
 consul_enable_dnsmasq: true

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ consul_acl_master_token: 'a5ac5cb6-c0d1-4aa3-bf9a-ca3507adc7ed'
 consul_acl_datacenter: "{{ consul_datacenter }}"
 
 # Define Consul ACLs within YAML
+# To apply ACLs, consul_enable_acls needs to be true and consul_acl_datacenter needs to be set.
+# The role will apply the ACLs only in consul_acl_datacenter as they are available in the whole WAN pool.
+# The role will also apply the ACLs only against one server as this is sufficient to set ACLs globally.
 # The double dash in rules in required as the Ansible module consul_acl expects one list with additional lists in it.
 # consul_acl:
 #   - mgmt_token: '3d3ae8b5-675e-467f-9616-2f0a82552742'

--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ consul_acl_master_token: 'a5ac5cb6-c0d1-4aa3-bf9a-ca3507adc7ed'
 # Defines the acl_datacenter which is authoritative for ACL information.
 consul_acl_datacenter: "{{ consul_datacenter }}"
 
+# Define Consul ACLs within YAML
+# The double dash in rules in required as the Ansible module consul_acl expects one list with additional lists in it.
+# consul_acl:
+#   - mgmt_token: '3d3ae8b5-675e-467f-9616-2f0a82552742'
+#     name: 'Foo access'
+#     token: '3cfc812f-6dc2-43f1-bceb-f10e8678f35d'
+#     rules:
+#       - - key: 'foo'
+#           policy: 'read'
+#         - key: 'private/foo'
+#           policy: 'write'
+#   - mgmt_token: "{{ variable_somewhere_else }}"
+#     name: 'Foo access 2'
+#     token: "{{ may_come_from_elsewhere_too }}"
+#     rules:
+#       - - node: 'my-node'
+#           policy: 'read'
+#         - service: ''
+#           policy: 'write'
+
 # Defines if dnsmasq should be installed and configured to resolv
 # consul dns queries to port 8600
 consul_enable_dnsmasq: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,26 @@ consul_acl_master_token: 'a5ac5cb6-c0d1-4aa3-bf9a-ca3507adc7ed'
 # Defines the acl_datacenter which is authoritative for ACL information.
 consul_acl_datacenter: "{{ consul_datacenter }}"
 
+# Define Consul ACLs within YAML
+# The double dash in rules in required as the Ansible module consul_acl expects one list with additional lists in it.
+# consul_acl:
+#   - mgmt_token: '3d3ae8b5-675e-467f-9616-2f0a82552742'
+#     name: 'Foo access'
+#     token: '3cfc812f-6dc2-43f1-bceb-f10e8678f35d'
+#     rules:
+#       - - key: 'foo'
+#           policy: 'read'
+#         - key: 'private/foo'
+#           policy: 'write'
+#   - mgmt_token: "{{ variable_somewhere_else }}"
+#     name: 'Foo access 2'
+#     token: "{{ may_come_from_elsewhere_too }}"
+#     rules:
+#       - - node: 'my-node'
+#           policy: 'read'
+#         - service: ''
+#           policy: 'write'
+
 # Defines if dnsmasq should be installed and configured to resolv
 # consul dns queries to port 8600
 consul_enable_dnsmasq: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,9 @@ consul_acl_master_token: 'a5ac5cb6-c0d1-4aa3-bf9a-ca3507adc7ed'
 consul_acl_datacenter: "{{ consul_datacenter }}"
 
 # Define Consul ACLs within YAML
+# To apply ACLs, consul_enable_acls needs to be true and consul_acl_datacenter needs to be set.
+# The role will apply the ACLs only in consul_acl_datacenter as they are available in the whole WAN pool.
+# The role will also apply the ACLs only against one server as this is sufficient to set ACLs globally.
 # The double dash in rules in required as the Ansible module consul_acl expects one list with additional lists in it.
 # consul_acl:
 #   - mgmt_token: '3d3ae8b5-675e-467f-9616-2f0a82552742'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,6 +73,10 @@ consul_acl_datacenter: "{{ consul_datacenter }}"
 #         - service: ''
 #           policy: 'write'
 
+# Defines if this role will install required Python modules on servers in consul_acl_datacenter in order to set ACLs via Ansible
+# Set to false if you wan't to install them in another way.
+consul_acl_install_requirements: true
+
 # Defines if dnsmasq should be installed and configured to resolv
 # consul dns queries to port 8600
 consul_enable_dnsmasq: true

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -1,7 +1,22 @@
 ---
-# should get applied only against one server but role does not support
-# last rule defined wins, not all
-# requires some python packages on the target
+- name: acl | install required Python modules via package manager
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python-requests
+    - python-pip
+  when: consul_acl_install_requirements
+
+- name: acl | install required Python modules via PIP
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python-consul
+    - pyhcl
+  when: consul_acl_install_requirements
+
 - name: acl | deploy Consul ACL's
   consul_acl:
     host: "{{ item.0.host | default(ansible_hostname) }}"

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -32,3 +32,4 @@
   with_subelements:
     - "{{ consul_acl }}"
     - rules
+  run_once: true

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -13,8 +13,7 @@
     token: "{{ item.0.token | default(omit) }}"
     token_type: "{{ item.0.token_type | default(omit) }}"
     validate_certs: "{{ item.0.validate_certs | default(omit) }}"
-    rules:
-      - "{{ item.1 }}"
+    rules: "{{ item.1 }}"
   with_subelements:
     - "{{ consul_acl }}"
     - rules

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -1,0 +1,20 @@
+---
+# should get applied only against one server but role does not support
+# last rule defined wins, not all
+# requires some python packages on the target
+- name: acl | deploy Consul ACL's
+  consul_acl:
+    host: "{{ item.0.host | default(ansible_hostname) }}"
+    port: "{{ item.0.port | default(omit) }}"
+    scheme: "{{ item.0.scheme | default(omit) }}"
+    state: "{{ item.0.state | default(omit) }}"
+    mgmt_token: "{{ item.0.mgmt_token }}"
+    name: "{{ item.0.name }}"
+    token: "{{ item.0.token | default(omit) }}"
+    token_type: "{{ item.0.token_type | default(omit) }}"
+    validate_certs: "{{ item.0.validate_certs | default(omit) }}"
+    rules:
+      - "{{ item.1 }}"
+  with_subelements:
+    - "{{ consul_acl }}"
+    - rules

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,11 @@
         consul_services is defined and
         consul_services
 
+- include: acl.yml
+  tags:
+    - consul-acl
+  when: consul_acl
+
 - include: dnsmasq.yml
   when: >
         consul_enable_dnsmasq is defined and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,8 @@
 - include: acl.yml
   tags:
     - consul-acl
-  when: consul_acl
+  when: consul_acl is defined and
+        consul_acl
 
 - include: dnsmasq.yml
   when: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,8 @@
   tags:
     - consul-acl
   when: consul_acl is defined and
-        consul_acl
+        consul_acl and
+        consul_datacenter == consul_acl_datacenter
 
 - include: dnsmasq.yml
   when: >


### PR DESCRIPTION
Hello @mrlesmithjr 

this PR comes via #49 and will allow the role user to define Consul ACLs with this role. This provides a simple, central, easy and reproducible way of defining ACLs for Consul. This attempt would be far saver then setting ACLs via WebGUI as this would not be reproducible at any time.

This PR utilizes [consul_acl](https://docs.ansible.com/ansible/latest/consul_acl_module.html).

Let me know what you think or you'd like to have something changed on it.

Best

Jard