### PR TITLE
Added acl_agent_master_token, acl_agent_token, and acl_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ consul_acl_replication_token: ''
 # make sure to generate a new token and replace this one
 consul_acl_master_token: 'a5ac5cb6-c0d1-4aa3-bf9a-ca3507adc7ed'
 
+# Define the additional and optional tokens for the agent. See official documentation for details.
+consul_acl_agent_master_token: ''
+consul_acl_agent_token: ''
+consul_acl_token: ''
+
 # Defines the acl_datacenter which is authoritative for ACL information.
 consul_acl_datacenter: "{{ consul_datacenter }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,11 @@ consul_acl_replication_token: ''
 # make sure to generate a new token and replace this one
 consul_acl_master_token: 'a5ac5cb6-c0d1-4aa3-bf9a-ca3507adc7ed'
 
+# Define the additional and optional tokens for the agent. See official documentation for details.
+consul_acl_agent_master_token: ''
+consul_acl_agent_token: ''
+consul_acl_token: ''
+
 # Defines the acl_datacenter which is authoritative for ACL information.
 consul_acl_datacenter: "{{ consul_datacenter }}"
 

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -3,6 +3,15 @@
 {%   if consul_enable_acls %}
 {%     set _config = config_json.update({"acl_datacenter": consul_acl_datacenter}) %}
 {%     set _config = config_json.update({"acl_down_policy": consul_acl_down_policy}) %}
+{%     if consul_acl_agent_master_token %}
+{%       set _config = config_json.update({"acl_agent_master_token": consul_acl_agent_master_token}) %}
+{%     endif %}
+{%     if consul_acl_agent_token %}
+{%       set _config = config_json.update({"acl_agent_token": consul_acl_agent_token}) %}
+{%     endif %}
+{%     if consul_acl_token %}
+{%       set _config = config_json.update({"acl_token": consul_acl_token}) %}
+{%     endif %}
 {%     if inventory_hostname in groups[consul_servers_group] %}
 {%       set _config = config_json.update({"acl_default_policy": consul_acl_default_policy}) %}
 {%       set _config = config_json.update({"acl_master_token": consul_acl_master_token}) %}


### PR DESCRIPTION
Hello @mrlesmithjr,

thanks for the last merge.
This allowed me to prepare this next one.
It allows the role user to set:
- acl_agent_master_token
- acl_agent_token
- acl_token
if he likes to.

[Official documentation](https://www.consul.io/docs/guides/acl.html#configuring-acls)
Best 

Jard