### PR TITLE
Retire sleep on service restart/reload

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,7 +11,6 @@
   service:
     name: "consul"
     state: "reloaded"
-    sleep: 10
   become: true
   when: not ansible_check_mode
 
@@ -19,7 +18,6 @@
   service:
     name: "consul"
     state: "restarted"
-    sleep: 10
   become: true
   when: not ansible_check_mode
 


### PR DESCRIPTION
Hi  @mrlesmithjr,

as referenced in #42 this PR removes the `sleep` parameter on consul service reload and restart.
On systemd based OS the option triggers a deprecation warning. First attempt was to add some systemd based handlers but this would have cause more code changes then actually required. As [documented](https://docs.ansible.com/ansible/latest/service_module.html) the `sleep` is for 
> If the service is being restarted then sleep this many seconds between the stop and start command. This helps to workaround badly behaving init scripts that exit immediately after signaling a process to stop.

As we're running our Consul clusters since version 0.8.x on systemd and ain't had any issues on that I'd like to remove the flag.

Best

Jard