### PR TITLE
added retry-join-wan option to join a existing federation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ consul_key_file: '/etc/consul.key'
 consul_mysql_password: 'consul'
 consul_mysql_user: 'consul'
 
+# An array of remote servers to use for retry-join-wan to join existing federation setup.
+consul_retry_join_wan: []
+# Static example
+# consul_retry_join_wan:
+#   - 266.277.288.299
+#   - 266.277.288.301
+#   - 266.277.288.302
+# Dynamic example when Ansible executing machine is running in Consul DNS aware environment
+# Note that the lookup requires dnspython on the Ansible executing machine to work
+# consul_retry_join_wan: "{{ lookup('dig', 'consul.service.nyc.consul.', wantlist=True) | ipaddr }}"
+
 # Defines the Ansible group which contains the consul server(s)
 consul_servers_group: 'consul_servers'
 
@@ -183,8 +194,6 @@ consul_version: '0.9.0'
 # Downgrades are not considered
 # Recommendation: When set to true and after raising `consul_version, consider using `--forks=1` on next Ansible run to keep Consul cluster impact low on Upgrade.
 consul_upgrade: false
-
-consul_wan_group: 'consul_wan'
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,6 +115,17 @@ consul_key_file: '/etc/consul.key'
 consul_mysql_password: 'consul'
 consul_mysql_user: 'consul'
 
+# An array of remote servers to use for retry-join-wan to join existing federation setup.
+consul_retry_join_wan: []
+# Static example
+# consul_retry_join_wan:
+#   - 266.277.288.299
+#   - 266.277.288.301
+#   - 266.277.288.302
+# Dynamic example when Ansible executing machine is running in Consul DNS aware environment
+# Note that the lookup requires dnspython on the Ansible executing machine to work
+# consul_retry_join_wan: "{{ lookup('dig', 'consul.service.nyc.consul.', wantlist=True) | ipaddr }}"
+
 # Defines the Ansible group which contains the consul server(s)
 consul_servers_group: 'consul_servers'
 
@@ -138,5 +149,3 @@ consul_version: '0.9.0'
 # Downgrades are not considered
 # Recommendation: When set to true and after raising `consul_version, consider using `--forks=1` on next Ansible run to keep Consul cluster impact low on Upgrade.
 consul_upgrade: false
-
-consul_wan_group: 'consul_wan'

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -54,6 +54,9 @@
 {%     set _config = config_json.update({"performance": consul_performance}) %}
 {%   endif %}
 {%     set _config = config_json.update({"retry_join": _temp_retry_join}) %}
+{%   if consul_retry_join_wan %}
+{%     set _config = config_json.update({"retry_join_wan": consul_retry_join_wan}) %}
+{%   endif %}
 {%   if consul_telemetry %}
 {%     set _config = config_json.update({"telemetry": consul_telemetry}) %}
 {%   endif %}


### PR DESCRIPTION
Hi @mrlesmithjr,

seems like I got an improvement attack on my side again.

This very nice change will allow the role user to utilize the [retry-join-wan](https://www.consul.io/docs/agent/options.html#_retry_join_wan) option of Consul. I found it to be useful after I setup a new cluster after activating ACLs. We set the the default police to deny which prevented a new cluster to assemble as it was not aware how to reach the acl_datacenter to "learn" that his token was allowed to assemble itself.

So in short if a new cluster know's how to reach the existing federation this would not have happened. The option added will allow this.

Best

Jard