### PR TITLE
Consul retry join wan on servers only

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ consul_mysql_password: 'consul'
 consul_mysql_user: 'consul'
 
 # An array of remote servers to use for retry-join-wan to join existing federation setup.
+# If you populate the array for all your Consul servers in one place, you may want to empty it again for your servers in the target datacenter again elsewhere.
+# Consul in the target datacenter won't complain if it's instructed to joint itself via WAN, but it might look a bit strange.
 consul_retry_join_wan: []
 # Static example
 # consul_retry_join_wan:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -116,6 +116,8 @@ consul_mysql_password: 'consul'
 consul_mysql_user: 'consul'
 
 # An array of remote servers to use for retry-join-wan to join existing federation setup.
+# If you populate the array for all your Consul servers in one place, you may want to empty it again for your servers in the target datacenter again elsewhere.
+# Consul in the target datacenter won't complain if it's instructed to joint itself via WAN, but it might look a bit strange.
 consul_retry_join_wan: []
 # Static example
 # consul_retry_join_wan:

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -54,8 +54,8 @@
 {%     set _config = config_json.update({"performance": consul_performance}) %}
 {%   endif %}
 {%     set _config = config_json.update({"retry_join": _temp_retry_join}) %}
-{%   if consul_retry_join_wan %}
-{%     set _config = config_json.update({"retry_join_wan": consul_retry_join_wan}) %}
+{%   if consul_retry_join_wan and inventory_hostname in groups[consul_servers_group] %}
+{%       set _config = config_json.update({"retry_join_wan": consul_retry_join_wan}) %}
 {%   endif %}
 {%   if consul_telemetry %}
 {%     set _config = config_json.update({"telemetry": consul_telemetry}) %}

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -55,7 +55,7 @@
 {%   endif %}
 {%     set _config = config_json.update({"retry_join": _temp_retry_join}) %}
 {%   if consul_retry_join_wan and inventory_hostname in groups[consul_servers_group] %}
-{%       set _config = config_json.update({"retry_join_wan": consul_retry_join_wan}) %}
+{%     set _config = config_json.update({"retry_join_wan": consul_retry_join_wan}) %}
 {%   endif %}
 {%   if consul_telemetry %}
 {%     set _config = config_json.update({"telemetry": consul_telemetry}) %}


### PR DESCRIPTION
Hi,

this small addon will ensure that the user can define `consul_retry_join_wan` globally and the role will add it only on servers.
Also a comment was added about purging `consul_retry_join_wan` for the servers in the target datacenter/s.

Best

Jard