### PR TITLE
allow user to configure consul_bind_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ consul_bin_owner: "{{ consul_user }}"
 consul_bin_group: "{{ consul_group }}"
 consul_bin_mode: '0750'
 
-# consul_bind_address: "{{ hostvars[inventory_hostname]['ansible_' + consul_bind_interface]['ipv4']['address'] }}"
+consul_bind_address: "{{ hostvars[inventory_hostname]['ansible_' + consul_bind_interface]['ipv4']['address'] }}"
 
 # Define interface to bind to...(eth0|eth1|enp0s8)
 consul_bind_interface: "{{ ansible_default_ipv4['interface'] | replace('-', '_') }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ consul_bin_owner: "{{ consul_user }}"
 consul_bin_group: "{{ consul_group }}"
 consul_bin_mode: '0750'
 
-# consul_bind_address: "{{ hostvars[inventory_hostname]['ansible_' + consul_bind_interface]['ipv4']['address'] }}"
+consul_bind_address: "{{ hostvars[inventory_hostname]['ansible_' + consul_bind_interface]['ipv4']['address'] }}"
 
 # Define interface to bind to...(eth0|eth1|enp0s8)
 consul_bind_interface: "{{ ansible_default_ipv4['interface'] | replace('-', '_') }}"

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -1,7 +1,7 @@
 ---
 - name: set_facts | Setting Facts
   set_fact:
-    consul_bind_address: "{{ hostvars[inventory_hostname]['ansible_' + consul_bind_interface]['ipv4']['address'] }}"
+    consul_bind_address: "{{ consul_bind_address }}"
 
 - name: set_facts | Show Consul Bind Interface
   debug: var=consul_bind_interface


### PR DESCRIPTION
Hi @mrlesmithjr,

this request will allow the user to adjust the `consul_bind_address`. Right now the set_facts way make it impossible to adjust this variable.
E.g. we needed this as some of our servers running in a routed environment where the IP to set for consul is a secondary IP on the loopback interface. Setting this was not possible in the current role state.

Best 

Jard