### PR TITLE
sort list consul_retry_join_wan

### DIFF
--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -55,7 +55,7 @@
 {%   endif %}
 {%     set _config = config_json.update({"retry_join": _temp_retry_join}) %}
 {%   if consul_retry_join_wan and inventory_hostname in groups[consul_servers_group] %}
-{%     set _config = config_json.update({"retry_join_wan": consul_retry_join_wan}) %}
+{%     set _config = config_json.update({"retry_join_wan": consul_retry_join_wan|sort}) %}
 {%   endif %}
 {%   if consul_telemetry %}
 {%     set _config = config_json.update({"telemetry": consul_telemetry}) %}


### PR DESCRIPTION
Hello @mrlesmithjr,

this small change will sort the fresh introduced list `consul_retry_join_wan`. I've noticed that Ansible will change the config on each role application, seems like the list gets shuffled.
If the list is sorted, the role no longer does unnecessary file changes and service restarts.

Best

Jard