### PR TITLE
added consul_peers_json_prepared:

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ consul_acl_datacenter: "{{ consul_datacenter }}"
 # Set to false if you wan't to install them in another way.
 consul_acl_install_requirements: true
 
+# Control if role will deploy a pre-populated peers.json for outage recovery purposes.
+# Checkout the official Consul documentation on "Outage Recovery" for details.
+consul_peers_json_prepared: false
+# Path where prepared json file should get placed at
+consul_peers_json_prepared_path: "{{ consul_data_dir }}/raft"
+
 # Defines if dnsmasq should be installed and configured to resolv
 # consul dns queries to port 8600
 consul_enable_dnsmasq: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,6 +91,12 @@ consul_acl_datacenter: "{{ consul_datacenter }}"
 # Set to false if you wan't to install them in another way.
 consul_acl_install_requirements: true
 
+# Control if role will deploy a pre-populated peers.json for outage recovery purposes.
+# Checkout the official Consul documentation on "Outage Recovery" for details.
+consul_peers_json_prepared: false
+# Path where prepared json file should get placed at
+consul_peers_json_prepared_path: "{{ consul_data_dir }}/raft"
+
 # Defines if dnsmasq should be installed and configured to resolv
 # consul dns queries to port 8600
 consul_enable_dnsmasq: true

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -34,3 +34,35 @@
     when: consul_encryption_key_active != consul_encryption_key
 
   when: keyring_exists.stat.exists
+
+- block:
+    - name: cluster | retrieve node ID
+      slurp:
+        src: "{{ consul_data_dir }}/node-id"
+      register: consul_node_id_b64
+      become: true
+
+    - name: cluster | Set consul_node_id fact
+      set_fact:
+        consul_node_id: "{{ consul_node_id_b64['content'] | b64decode }}"
+
+    - name: cluster | deploy peers.json_prepared
+      template:
+        src: "templates/var/consul/peers.json_prepared.j2"
+        dest: "{{ consul_peers_json_prepared_path }}/peers.json_prepared"
+        owner: "{{ consul_user }}"
+        group: "{{ consul_group }}"
+        mode: "0640"
+      become: true
+      when: not ansible_check_mode
+
+  when: consul_peers_json_prepared and
+        inventory_hostname in groups[consul_servers_group]
+
+- name: cluster | ensure absence of peers.json_prepared if desired
+  file:
+    path: "{{ consul_peers_json_prepared_path }}/peers.json_prepared"
+    state: absent
+  become: true
+  when: not consul_peers_json_prepared and
+        not ansible_check_mode

--- a/templates/var/consul/peers.json_prepared.j2
+++ b/templates/var/consul/peers.json_prepared.j2
@@ -1,0 +1,8 @@
+{% set peers_json_prepared = [] %}
+{%   for fqdn in groups[consul_servers_group] %}
+{%   set nodeblock = {} %}
+{%     set _placeholder = nodeblock.update({"address": hostvars[fqdn]['consul_bind_address']}) %}
+{%     set _placeholder = nodeblock.update({"id": hostvars[fqdn]['consul_node_id']}) %}
+{%     set _placeholder = peers_json_prepared.append(nodeblock) %}
+{%   endfor %}
+{{ peers_json_prepared|to_nice_json }}


### PR DESCRIPTION
Hello @mrlesmithjr,

through our experiences we made with Consul here comes an optional improvement to support admins on a cluster outage recovers.
This PR enables the role to deploy a pre-populates `peers.json` on each server. As [documented](https://www.consul.io/docs/guides/outage.html#manual-recovery-using-peers-json) the file is used to manually create a strict conses about which servers should participate in the raft pool.
The user would have to rename it from `peers.json_prepared` to `peers.json` so Consul would grab it on a restart.

This is a opt-in feature, so the user have to enable it if he would like to have it.

Let me know what you think or what could be done better on this.

Best

Jard