### PR TITLE
allow user to define custom retry-join array

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ consul_runas_user: true
 consul_mysql_password: 'consul'
 consul_mysql_user: 'consul'
 
+# An array of servers to use for retry-join to join existing cluster. # See official documentation of `-retry-join` for possible use cases.
+# If empty, the role will populate the array with the IP addresses from hosts in `consul_servers_group` which need to be part of the play.
+# Thus defining values here act as an override of the auto population and allows more fine grained plays with out servers in it.
+consul_retry_join: []
+
 # An array of remote servers to use for retry-join-wan to join existing federation setup.
 # If you populate the array for all your Consul servers in one place, you may want to empty it again for your servers in the target datacenter again elsewhere.
 # Consul in the target datacenter won't complain if it's instructed to joint itself via WAN, but it might look a bit strange.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,6 +115,11 @@ consul_runas_user: true
 consul_mysql_password: 'consul'
 consul_mysql_user: 'consul'
 
+# An array of servers to use for retry-join to join existing cluster. # See official documentation of `-retry-join` for possible use cases.
+# If empty, the role will populate the array with the IP addresses from hosts in `consul_servers_group` which need to be part of the play.
+# Thus defining values here act as an override of the auto population and allows more fine grained plays with out servers in it.
+consul_retry_join: []
+
 # An array of remote servers to use for retry-join-wan to join existing federation setup.
 # If you populate the array for all your Consul servers in one place, you may want to empty it again for your servers in the target datacenter again elsewhere.
 # Consul in the target datacenter won't complain if it's instructed to joint itself via WAN, but it might look a bit strange.

--- a/templates/etc/consul.d/config.json.j2
+++ b/templates/etc/consul.d/config.json.j2
@@ -42,17 +42,21 @@
 {%   else %}
 {%     set _config = config_json.update({"server": false}) %}
 {%   endif %}
+{%   if consul_retry_join %}
+{%     set _config = config_json.update({"retry_join": consul_retry_join|sort }) %}
+{%   else %}
 {%     set _temp_retry_join = [] %}
-{%   for host in groups[consul_servers_group] %}
-{%     if inventory_hostname != host %}
-{%       set _temp_ip = hostvars[host]['consul_bind_address'] %}
-{%       set _ = _temp_retry_join.append(_temp_ip) %}
-{%     endif %}
-{%   endfor %}
+{%     for host in groups[consul_servers_group] %}
+{%       if inventory_hostname != host %}
+{%         set _temp_ip = hostvars[host]['consul_bind_address'] %}
+{%         set _ = _temp_retry_join.append(_temp_ip) %}
+{%       endif %}
+{%     endfor %}
+{%     set _config = config_json.update({"retry_join": _temp_retry_join}) %}
+{%   endif %}
 {%   if consul_performance %}
 {%     set _config = config_json.update({"performance": consul_performance}) %}
 {%   endif %}
-{%     set _config = config_json.update({"retry_join": _temp_retry_join}) %}
 {%   if consul_retry_join_wan and inventory_hostname in groups[consul_servers_group] %}
 {%     set _config = config_json.update({"retry_join_wan": consul_retry_join_wan|sort}) %}
 {%   endif %}


### PR DESCRIPTION
Hi @mrlesmithjr,

this request will give the user the ability to define a custom array for `consul_retry_join`. This makes it possible to run the role against a set of hosts where the `consul_servers_group` are not part of, which is a requirement right now.

This makes it easier to deploy and configure Consul agents in larger environments and improves the role handling for Consul unaware users.


As always with best regards

Jard