### PR TITLE
Fix 'Not Fedora' add'l dependencies play in redhat install so they run.

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -36,4 +36,4 @@
     - 'jq'
     - 'tree'
     - 'unzip'
-  when: ansible_distribution == "Fedora"
+  when: ansible_distribution != "Fedora"


### PR DESCRIPTION
In the current version the 'Not Fedora' play to install additional dependencies will not run since it is set to check if the distribution IS Fedora. This Pull Request changes the check to see if the distribution is NOT fedora which allows it to run.